### PR TITLE
Add rawBytes to BarcodeValue 

### DIFF
--- a/android/src/main/java/com/google_ml_kit/vision/BarcodeDetector.java
+++ b/android/src/main/java/com/google_ml_kit/vision/BarcodeDetector.java
@@ -90,6 +90,7 @@ public class BarcodeDetector implements ApiDetectorInterface {
                             int valueType = barcode.getValueType();
                             barcodeMap.put("type", valueType);
                             barcodeMap.put("rawValue", barcode.getRawValue());
+                            barcodeMap.put("rawBytes", barcode.getRawBytes());
                             barcodeMap.put("displayValue", barcode.getDisplayValue());
                             Rect bb = barcode.getBoundingBox();
                             if (bb != null) {

--- a/ios/Classes/vision/BarcodeScanner.m
+++ b/ios/Classes/vision/BarcodeScanner.m
@@ -57,6 +57,7 @@
     [dictionary addEntriesFromDictionary:@{
         @"type" : @(barcode.valueType) ?: [NSNull null],
         @"rawValue" : barcode.rawValue ?: [NSNull null],
+        @"rawBytes" : barcode.rawData ?: [NSNull null],
         @"displayValue" : barcode.displayValue ?: [NSNull null],
         @"boundingBoxLeft" : @(barcode.frame.origin.x),
         @"boundingBoxTop" : @(barcode.frame.origin.y),

--- a/lib/src/vision/barcode_scanner.dart
+++ b/lib/src/vision/barcode_scanner.dart
@@ -190,6 +190,11 @@ class BarcodeValue {
   /// Null if nothing found.
   final String? rawValue;
 
+  /// Barcode bytes as encoded in the barcode.
+  ///
+  /// Null if nothing found.
+  final Uint8List? rawBytes;
+
   /// Barcode value in a user-friendly format.
   /// This value may be multiline, for example, when line breaks are encoded into the original TEXT barcode value.
   /// May include the supplement value.
@@ -205,6 +210,7 @@ class BarcodeValue {
   BarcodeValue._fromMap(Map<dynamic, dynamic> barcodeData)
       : type = BarcodeType.values[barcodeData['type']],
         rawValue = barcodeData['rawValue'],
+        rawBytes = barcodeData['rawBytes'],
         displayValue = barcodeData['displayValue'],
         boundingBox = barcodeData['boundingBoxLeft'] != null
             ? Rect.fromLTRB(


### PR DESCRIPTION
@bharat-biradar Hi there :)

In short, this PR adds rawBytes to the ```BarcodeValue``` class.

I'll provide some background to motivate why this would be a valuable addition. I had a requirement when scanning barcodes not encoded using UTF8. The only way I code extract valuable information from these barcodes was through accessing the raw bytes of the barcodes. Hence, I raised an issue and opened a PR on the ```firebase_ml_vision ``` plugin, please see the links below for context:
- https://github.com/FirebaseExtended/flutterfire/issues/1816
- https://github.com/FirebaseExtended/flutterfire/pull/2368

Aside from myself, there are quite a few others who also wanted to see this feature go in (judging by the activity on the Issue and the PR). However, since the ```firebase_ml_vision ``` was discontinued, the PR was closed and I was directed to use this plugin instead. Consequently I'd like to propose adding this feature :-)

I have tested the change on iOS and Android devices and both are working. Please let me know if there is anything I am missing or you would like me to add :-)

Also, since this is quite a small change I have not raised an issue for it, but will be happy to do so on request. Thanks in advance for your help.