### PR TITLE
Change available API's to use unbundled models

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ A Flutter plugin to use [Google's standalone ML Kit](https://developers.google.c
 
 ## Requirements
 
-###iOS
+### iOS
 
 - Minimum iOS Deployment Target: 10.0
 - Xcode 12 or newer
@@ -82,19 +82,22 @@ Notice that the minimum `IPHONEOS_DEPLOYMENT_TARGET` is 10.0, you can set it to 
 Add this plugin as dependency in your pubspec.yaml.
 
 - In your project-level build.gradle file, make sure to include Google's Maven repository in both your buildscript and allprojects sections(for all api's).
-- All API's except `Image Labeling`, `Face Detection` and `Barcode Scanning` use bundled models, hence others should work 
-  out of the box.
-- For Api's using unbundled models, configure your application to download the model to your device automatically
-  from play store by adding the following to your app's `AndroidManifest.xml`
+- All API's except `Image Labeling`, `Face Detection` and `Barcode Scanning` use bundled models, hence others should work out of the box.
+- For Api's using unbundled models, configure your application to download the model to your device automatically from play store by adding the following to your app's `AndroidManifest.xml`
+
   ```xml
   <meta-data
           android:name="com.google.mlkit.vision.DEPENDENCIES"
           android:value="ica" />
       <!-- To use multiple models: android:value="ica,model2,model3" -->
   ```
+  
+  Use these options:
+  
   - **ica** - `Image Labeling`
   - **ocr** - `Barcode Scanning`
   - **face** -`Face Detection`
+
 #### 1. Create an InputImage
 
 From path:

--- a/README.md
+++ b/README.md
@@ -82,8 +82,19 @@ Notice that the minimum `IPHONEOS_DEPLOYMENT_TARGET` is 10.0, you can set it to 
 Add this plugin as dependency in your pubspec.yaml.
 
 - In your project-level build.gradle file, make sure to include Google's Maven repository in both your buildscript and allprojects sections(for all api's).
-- The plugin has been written using bundled api models, this implies models will be bundled along with plugin and there is no need to implement any dependencies on your part and should work out of the box.
-
+- All API's except `Image Labeling`, `Face Detection` and `Barcode Scanning` use bundled models, hence others should work 
+  out of the box.
+- For Api's using unbundled models, configure your application to download the model to your device automatically
+  from play store by adding the following to your app's `AndroidManifest.xml`
+  ```xml
+  <meta-data
+          android:name="com.google.mlkit.vision.DEPENDENCIES"
+          android:value="ica" />
+      <!-- To use multiple models: android:value="ica,model2,model3" -->
+  ```
+  - **ica** - `Image Labeling`
+  - **ocr** - `Barcode Scanning`
+  - **face** -`Face Detection`
 #### 1. Create an InputImage
 
 From path:

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Add this plugin as dependency in your pubspec.yaml.
 
 - In your project-level build.gradle file, make sure to include Google's Maven repository in both your buildscript and allprojects sections(for all api's).
 - All API's except `Image Labeling`, `Face Detection` and `Barcode Scanning` use bundled models, hence others should work out of the box.
-- For Api's using unbundled models, configure your application to download the model to your device automatically from play store by adding the following to your app's `AndroidManifest.xml`
+- For API's using unbundled models, configure your application to download the model to your device automatically from play store by adding the following to your app's `AndroidManifest.xml`, if not configured the respective models will be downloaded when the API's are invoked for the first time. 
 
   ```xml
   <meta-data

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -35,9 +35,9 @@ android {
 
 }
 dependencies {
-    implementation 'com.google.mlkit:barcode-scanning:16.2.0'
+    implementation 'com.google.android.gms:play-services-mlkit-barcode-scanning:16.2.0'
 
-    implementation 'com.google.mlkit:image-labeling:17.0.5'
+    implementation 'com.google.android.gms:play-services-mlkit-image-labeling:16.0.5'
     implementation 'com.google.mlkit:image-labeling-custom:16.3.1'
     implementation 'com.google.mlkit:image-labeling-automl:16.2.1'
 
@@ -57,5 +57,5 @@ dependencies {
     implementation 'com.google.mlkit:object-detection-custom:16.3.3'
     implementation 'com.google.mlkit:linkfirebase:16.1.1'
 
-    implementation 'com.google.mlkit:face-detection:16.1.2'
+    implementation 'com.google.android.gms:play-services-mlkit-face-detection:16.2.0'
 }

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -42,6 +42,9 @@
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
         </activity>
+        <meta-data
+          android:name="com.google.mlkit.vision.DEPENDENCIES"
+          android:value="ica,ocr,face" />
         <!-- Don't delete the meta-data below.
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->
         <meta-data


### PR DESCRIPTION
Fix for issue #76 

#### Change following API's to use unbundled models instead of bundled models for Android
* `Face Detection`
* `Image labeling` (Base Model)
* `Barcode scanning`