### PR TITLE
MOD gitignore for simulator `dpgh` files

### DIFF
--- a/example/ios/.gitignore
+++ b/example/ios/.gitignore
@@ -25,6 +25,9 @@ Flutter/flutter_export_environment.sh
 ServiceDefinitions.json
 Runner/GeneratedPluginRegistrant.*
 
+# Pods.build `dgph` files -- this rule ignores weird simulator files asscosciated with Firebase/MLKit pods
+build
+
 # Exceptions to above rules.
 !default.mode1v3
 !default.mode2v3


### PR DESCRIPTION
- This issue appears when using simulator to build your app.
- Appeared on `Xcode 12.5.1` & `flutter 2.5.0`