### PR TITLE
Added corner points to barcodes for proper QR outlining

### DIFF
--- a/android/src/main/java/com/google_ml_kit/vision/BarcodeDetector.java
+++ b/android/src/main/java/com/google_ml_kit/vision/BarcodeDetector.java
@@ -1,6 +1,7 @@
 package com.google_ml_kit.vision;
 
 import android.content.Context;
+import android.graphics.Point;
 import android.graphics.Rect;
 
 import androidx.annotation.NonNull;
@@ -14,6 +15,7 @@ import com.google.mlkit.vision.barcode.BarcodeScanning;
 import com.google.mlkit.vision.common.InputImage;
 import com.google_ml_kit.ApiDetectorInterface;
 
+import java.lang.reflect.Array;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -93,6 +95,17 @@ public class BarcodeDetector implements ApiDetectorInterface {
                             barcodeMap.put("rawValue", barcode.getRawValue());
                             barcodeMap.put("rawBytes", barcode.getRawBytes());
                             barcodeMap.put("displayValue", barcode.getDisplayValue());
+                            Point[] corners = barcode.getCornerPoints();
+                            if(corners != null) {
+                                int [] x = new int[corners.length];
+                                int [] y = new int[corners.length];
+                                for(int i = 0; i < corners.length; i++) {
+                                    x[i] = corners[i].x;
+                                    y[i] = corners[i].y;
+                                }
+                                barcodeMap.put("cornerPointsX", x);
+                                barcodeMap.put("cornerPointsY", y);
+                            }
                             Rect bb = barcode.getBoundingBox();
                             if (bb != null) {
                                 barcodeMap.put("boundingBoxBottom", bb.bottom);

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -23,7 +23,6 @@ if (flutterVersionName == null) {
 
 apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
-apply plugin: 'com.google.gms.google-services'
 
 android {
     compileSdkVersion 29

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -7,7 +7,6 @@ buildscript {
 
     dependencies {
         classpath 'com.android.tools.build:gradle:4.1.2'
-        classpath 'com.google.gms:google-services:4.3.8'
     }
 }
 

--- a/example/lib/VisionDetectorViews/painters/barcode_detector_painter.dart
+++ b/example/lib/VisionDetectorViews/painters/barcode_detector_painter.dart
@@ -1,3 +1,4 @@
+import 'dart:math';
 import 'dart:ui';
 import 'dart:ui' as ui;
 
@@ -34,14 +35,49 @@ class BarcodeDetectorPainter extends CustomPainter {
       builder.addText('${barcode.value.displayValue}');
       builder.pop();
 
-      final left = translateX(
-          barcode.value.boundingBox!.left, rotation, size, absoluteImageSize);
-      final top = translateY(
-          barcode.value.boundingBox!.top, rotation, size, absoluteImageSize);
-      final right = translateX(
-          barcode.value.boundingBox!.right, rotation, size, absoluteImageSize);
-      final bottom = translateY(
-          barcode.value.boundingBox!.bottom, rotation, size, absoluteImageSize);
+      // Store the points for the bounding box
+      double left = double.infinity;
+      double top = double.infinity;
+      double right = double.negativeInfinity;
+      double bottom = double.negativeInfinity;
+
+      var cornerPoints = barcode.value.cornerPoints;
+      if (cornerPoints == null) {
+        left = translateX(
+            barcode.value.boundingBox!.left, rotation, size, absoluteImageSize);
+        top = translateY(
+            barcode.value.boundingBox!.top, rotation, size, absoluteImageSize);
+        right = translateX(barcode.value.boundingBox!.right, rotation,
+            size, absoluteImageSize);
+        bottom = translateY(barcode.value.boundingBox!.bottom, rotation,
+            size, absoluteImageSize);
+
+        // Draw a bounding rectangle around the barcode
+        canvas.drawRect(
+          Rect.fromLTRB(left, top, right, bottom),
+          paint,
+        );
+      } else {
+        List<Offset> offsetPoints = <Offset>[];
+
+        for (var point in cornerPoints) {
+          double x =
+              translateX(point.x.toDouble(), rotation, size, absoluteImageSize);
+          double y =
+              translateY(point.y.toDouble(), rotation, size, absoluteImageSize);
+
+          offsetPoints.add(Offset(x, y));
+
+          // Due to possible rotations we need to find the smallest and largest
+          top = min(top, y);
+          bottom = max(bottom, y);
+          left = min(left, x);
+          right = max(right, x);
+        }
+        // Add the first point to close the polygon
+        offsetPoints.add(offsetPoints.first);
+        canvas.drawPoints(PointMode.polygon, offsetPoints, paint);
+      }
 
       canvas.drawParagraph(
         builder.build()
@@ -49,11 +85,6 @@ class BarcodeDetectorPainter extends CustomPainter {
             width: right - left,
           )),
         Offset(left, top),
-      );
-
-      canvas.drawRect(
-        Rect.fromLTRB(left, top, right, bottom),
-        paint,
       );
     }
   }

--- a/example/lib/VisionDetectorViews/painters/barcode_detector_painter.dart
+++ b/example/lib/VisionDetectorViews/painters/barcode_detector_painter.dart
@@ -47,10 +47,10 @@ class BarcodeDetectorPainter extends CustomPainter {
             barcode.value.boundingBox!.left, rotation, size, absoluteImageSize);
         top = translateY(
             barcode.value.boundingBox!.top, rotation, size, absoluteImageSize);
-        right = translateX(barcode.value.boundingBox!.right, rotation,
-            size, absoluteImageSize);
-        bottom = translateY(barcode.value.boundingBox!.bottom, rotation,
-            size, absoluteImageSize);
+        right = translateX(barcode.value.boundingBox!.right, rotation, size,
+            absoluteImageSize);
+        bottom = translateY(barcode.value.boundingBox!.bottom, rotation, size,
+            absoluteImageSize);
 
         // Draw a bounding rectangle around the barcode
         canvas.drawRect(

--- a/lib/src/vision/barcode_scanner.dart
+++ b/lib/src/vision/barcode_scanner.dart
@@ -284,6 +284,12 @@ class BarcodeValue {
   /// Could be null if the bounding rectangle can not be determined.
   final Rect? boundingBox;
 
+  /// The corner points of the detected barcode.
+  ///
+  /// These are useful to detect the orientation and adjust for skew
+  /// Could be null if the points could not be determined.
+  final List<Point>? cornerPoints;
+
   BarcodeValue._(Map<dynamic, dynamic> barcodeData)
       : type = BarcodeType.values[barcodeData['type']],
         format = _BarcodeFormatValue.of(barcodeData['format']),
@@ -292,11 +298,12 @@ class BarcodeValue {
         displayValue = barcodeData['displayValue'],
         boundingBox = barcodeData['boundingBoxLeft'] != null
             ? Rect.fromLTRB(
-                (barcodeData['boundingBoxLeft']).toDouble(),
-                (barcodeData['boundingBoxTop']).toDouble(),
-                (barcodeData['boundingBoxRight']).toDouble(),
-                (barcodeData['boundingBoxBottom']).toDouble())
-            : null;
+            (barcodeData['boundingBoxLeft']).toDouble(),
+            (barcodeData['boundingBoxTop']).toDouble(),
+            (barcodeData['boundingBoxRight']).toDouble(),
+            (barcodeData['boundingBoxBottom']).toDouble())
+            : null,
+        cornerPoints = barcodeData['cornerPointsX'] != null ? [for(int i=0; i<barcodeData['cornerPointsX'].length; i++)Point(barcodeData['cornerPointsX'][i], barcodeData['cornerPointsY'][i])] : null;
 }
 
 /// Class to store wifi info obtained from a barcode.

--- a/lib/src/vision/barcode_scanner.dart
+++ b/lib/src/vision/barcode_scanner.dart
@@ -298,12 +298,18 @@ class BarcodeValue {
         displayValue = barcodeData['displayValue'],
         boundingBox = barcodeData['boundingBoxLeft'] != null
             ? Rect.fromLTRB(
-            (barcodeData['boundingBoxLeft']).toDouble(),
-            (barcodeData['boundingBoxTop']).toDouble(),
-            (barcodeData['boundingBoxRight']).toDouble(),
-            (barcodeData['boundingBoxBottom']).toDouble())
+                (barcodeData['boundingBoxLeft']).toDouble(),
+                (barcodeData['boundingBoxTop']).toDouble(),
+                (barcodeData['boundingBoxRight']).toDouble(),
+                (barcodeData['boundingBoxBottom']).toDouble())
             : null,
-        cornerPoints = barcodeData['cornerPointsX'] != null ? [for(int i=0; i<barcodeData['cornerPointsX'].length; i++)Point(barcodeData['cornerPointsX'][i], barcodeData['cornerPointsY'][i])] : null;
+        cornerPoints = barcodeData['cornerPointsX'] != null
+            ? [
+                for (int i = 0; i < barcodeData['cornerPointsX'].length; i++)
+                  Point(barcodeData['cornerPointsX'][i],
+                      barcodeData['cornerPointsY'][i])
+              ]
+            : null;
 }
 
 /// Class to store wifi info obtained from a barcode.

--- a/lib/src/vision/vision.dart
+++ b/lib/src/vision/vision.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:io';
+import 'dart:math';
 import 'dart:typed_data';
 
 import 'package:flutter/cupertino.dart';


### PR DESCRIPTION
Instead of always displaying a straight up rectangle, we can now display the full polygon around the QR instead:
![image](https://user-images.githubusercontent.com/270571/143771374-a675e4fe-a376-407f-9f73-df27c9279fb2.png)
