### PR TITLE
Handle all possible values of `StrokePoint.t`

### DIFF
--- a/packages/google_mlkit_digital_ink_recognition/android/src/main/java/com/google_mlkit_digital_ink_recognition/DigitalInkRecognizer.java
+++ b/packages/google_mlkit_digital_ink_recognition/android/src/main/java/com/google_mlkit_digital_ink_recognition/DigitalInkRecognizer.java
@@ -74,7 +74,13 @@ public class DigitalInkRecognizer implements MethodChannel.MethodCallHandler {
             for (final Map<String, Object> point : pointsList) {
                 float x = (float) (double) point.get("x");
                 float y = (float) (double) point.get("y");
-                long t = (long) point.get("t");
+                Object t0 = point.get("t");
+                long t;
+                if (t0 instanceof Integer) {
+                    t = (int) t0;
+                } else {
+                    t = (long) t0;   
+                }
                 Ink.Point strokePoint = Ink.Point.create(x, y, t);
                 strokeBuilder.addPoint(strokePoint);
             }


### PR DESCRIPTION
Flutter serializes any integer less than 2^32 [as an `int` instead of a `long`](https://docs.flutter.dev/development/platform-integration/platform-channels?tab=type-mappings-java-tab), so trying to pass a small number as `t` causes a `ClassCastException` here (see #242, which was prematurely closed by the OP).

This probably should be put in a helper function and sprinkled throughout the codebase, but this is the only place I've encountered it so far.