### PR TITLE
fix: TextBlock type cast on readme

### DIFF
--- a/packages/google_mlkit_object_detection/README.md
+++ b/packages/google_mlkit_object_detection/README.md
@@ -115,6 +115,7 @@ final options = LocalObjectDetectorOptions(
   modelPath: modelPath,
   classifyObjects: true,
   multipleObjects: true,
+  mode: DetectionMode.stream,
 );
 final objectDetector = ObjectDetector(options: options);
 ```

--- a/packages/google_mlkit_text_recognition/README.md
+++ b/packages/google_mlkit_text_recognition/README.md
@@ -66,11 +66,11 @@ final RecognizedText recognizedText = await textRecognizer.processImage(inputIma
 
 String text = recognizedText.text;
 for (TextBlock block in recognizedText.blocks) {
-  final Rect rect = block.rect;
-  final List<Offset> cornerPoints = block.cornerPoints;
+  final Rect rect = block.boundingBox;
+  final List<Point<int>> cornerPoints = block.cornerPoints;
   final String text = block.text;
   final List<String> languages = block.recognizedLanguages;
-
+  
   for (TextLine line in block.lines) {
     // Same getters as TextBlock
     for (TextElement element in line.elements) {


### PR DESCRIPTION
Fix the TextBlock property which is `boundingBox` not `rect`
And also `cornerPoints` as a return type of `List<Point<int>>`  not `List<Offset>`

While Object Detection -> LocalObjectDetectorOptions require mode which can be `DetectionMode.stream` or `DetectionMode.single`
Thank you