### PR TITLE
chore: bump entity-extraction API to 16.0.0-beta6

### DIFF
--- a/packages/google_mlkit_entity_extraction/android/build.gradle
+++ b/packages/google_mlkit_entity_extraction/android/build.gradle
@@ -36,6 +36,6 @@ android {
     }
 
     dependencies {
-        implementation("com.google.mlkit:entity-extraction:16.0.0-beta5")
+        implementation("com.google.mlkit:entity-extraction:16.0.0-beta6")
     }
 }


### PR DESCRIPTION
Bumps entity extraction to 16.0.0-beta6 to resolve 16KB page sizes per https://developers.google.com/ml-kit/release-notes#april_18_2025

Resolves #801