### PR TITLE
fix(document_scanner): prevent 'Reply already submitted' on duplicate activity result

### DIFF
--- a/packages/google_mlkit_document_scanner/android/src/main/kotlin/com/google_mlkit_document_scanner/DocumentScanner.kt
+++ b/packages/google_mlkit_document_scanner/android/src/main/kotlin/com/google_mlkit_document_scanner/DocumentScanner.kt
@@ -61,7 +61,7 @@ class DocumentScanner(
         if (scanner == null) {
             val options =
                 call.argument<Map<String, Any>>("options") ?: run {
-                    result.error(TAG, "Invalid options", null)
+                    consumePendingResult()?.error(TAG, "Invalid options", null)
                     return
                 }
             val scannerOptions = parseOptions(options)
@@ -76,10 +76,10 @@ class DocumentScanner(
                 try {
                     activity.startIntentSenderForResult(intentSender, START_DOCUMENT_ACTIVITY, null, 0, 0, 0)
                 } catch (e: IntentSender.SendIntentException) {
-                    result.error(TAG, "Failed to start document scanner", null)
+                    consumePendingResult()?.error(TAG, "Failed to start document scanner", null)
                 }
             }.addOnFailureListener {
-                result.error(TAG, "Failed to start document scanner", null)
+                consumePendingResult()?.error(TAG, "Failed to start document scanner", null)
             }
     }
 
@@ -141,11 +141,11 @@ class DocumentScanner(
                 }
 
                 Activity.RESULT_CANCELED -> {
-                    pendingResult?.error(TAG, "Operation cancelled", null)
+                    consumePendingResult()?.error(TAG, "Operation cancelled", null)
                 }
 
                 else -> {
-                    pendingResult?.error(TAG, "Unknown Error", null)
+                    consumePendingResult()?.error(TAG, "Unknown Error", null)
                 }
             }
             return true
@@ -154,6 +154,8 @@ class DocumentScanner(
     }
 
     private fun handleScanningResult(result: GmsDocumentScanningResult) {
+        val reply = consumePendingResult() ?: return
+
         val resultMap = HashMap<String, Any?>()
 
         val pdf = result.pdf
@@ -174,6 +176,18 @@ class DocumentScanner(
             resultMap["images"] = null
         }
 
-        pendingResult?.success(resultMap)
+        reply.success(resultMap)
+    }
+
+    /**
+     * Atomically returns the current [pendingResult] and clears the field, so a subsequent
+     * duplicate callback (e.g. a redelivered activity result on some OEM builds) cannot submit
+     * a second reply on the same [MethodChannel.Result] and trigger
+     * `IllegalStateException: Reply already submitted`.
+     */
+    private fun consumePendingResult(): MethodChannel.Result? {
+        val reply = pendingResult
+        pendingResult = null
+        return reply
     }
 }


### PR DESCRIPTION
## Summary

Fixes `IllegalStateException: Reply already submitted` thrown from `DocumentScanner.handleScanningResult` (and the cancel/error paths) when the platform delivers `onActivityResult` more than once for the same `START_DOCUMENT_ACTIVITY` request code.

Fixes #857.

## Root cause

`DocumentScanner` stores the caller's `MethodChannel.Result` in `pendingResult` but never clears the field after completing it:

```kotlin
// before
pendingResult?.success(resultMap)            // in handleScanningResult
pendingResult?.error(TAG, "Operation cancelled", null)  // in onActivityResult
// ...pendingResult still non-null, pointing at an already-completed reply
```

If the OS then redelivers the activity result — which ColorOS (Oppo) is observed to do across certain lifecycle transitions — the second `onActivityResult` invocation calls `.success(...)` / `.error(...)` on the already-completed `MethodChannel.Result`, and `DartMessenger$Reply.reply` throws `IllegalStateException: Reply already submitted`, crashing the host app.

Stack trace (abridged) from the linked issue:

```
Caused by java.lang.IllegalStateException: Reply already submitted
    at io.flutter.embedding.engine.dart.DartMessenger$Reply.reply(DartMessenger.java:425)
    at io.flutter.plugin.common.MethodChannel$IncomingMethodCallHandler$1.success(MethodChannel.java:272)
    at com.google_mlkit_document_scanner.DocumentScanner.handleScanningResult(DocumentScanner.kt:...)
    at com.google_mlkit_document_scanner.DocumentScanner.onActivityResult(DocumentScanner.kt:...)
    at io.flutter.embedding.engine.FlutterEngineConnectionRegistry$FlutterEngineActivityPluginBinding.onActivityResult(...)
```

## Fix

Introduce a `consumePendingResult()` helper that atomically returns the current `pendingResult` and nulls the field, and route every submission site through it:

- `handleScanningResult` (success path)
- `onActivityResult` `RESULT_CANCELED` / unknown result branches
- `handleScanner` error paths (invalid options, intent-sender failures)

A redelivered activity result now short-circuits via the null receiver (`consumePendingResult()?.xxx(...)`) instead of double-submitting.

```kotlin
private fun consumePendingResult(): MethodChannel.Result? {
    val reply = pendingResult
    pendingResult = null
    return reply
}
```

The change is confined to one file: `packages/google_mlkit_document_scanner/android/src/main/kotlin/com/google_mlkit_document_scanner/DocumentScanner.kt` (+20/-6).

## Validation

- `flutter build apk --debug` on `packages/example` compiles cleanly against the patched Kotlin source.
- The user-facing crash cannot be reproduced on demand (it is OEM-specific timing triggered by ColorOS redelivery), but the mechanism is eliminated: after the first `.success()` / `.error()`, `pendingResult` is null and any subsequent callback is a no-op.

## Suggested CHANGELOG entry (for maintainers)

```
## 0.4.2

* Fix `IllegalStateException: Reply already submitted` crash when `onActivityResult` is
  delivered more than once (observed on Oppo/ColorOS devices).
```

I did not bump the package version in this PR — leaving that to the maintainer release cadence.

## Test plan

- [x] `flutter build apk --debug` on `packages/example` — passes.
- [ ] Happy path smoke test on an Android device (maintainers).
- [ ] Cancel path smoke test (maintainers).