### PR TITLE
fix: bump Android compileSdk to 36 across all plugins for AGP 9 compatibility

### DIFF
--- a/packages/google_mlkit_barcode_scanning/android/build.gradle
+++ b/packages/google_mlkit_barcode_scanning/android/build.gradle
@@ -27,7 +27,7 @@ apply plugin: "kotlin-android"
 android {
     namespace = "com.google_mlkit_barcode_scanning"
 
-    compileSdk = 35
+    compileSdk = 36
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11

--- a/packages/google_mlkit_commons/android/build.gradle
+++ b/packages/google_mlkit_commons/android/build.gradle
@@ -27,7 +27,7 @@ apply plugin: "kotlin-android"
 android {
     namespace = "com.google_mlkit_commons"
 
-    compileSdk = 35
+    compileSdk = 36
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11

--- a/packages/google_mlkit_digital_ink_recognition/android/build.gradle
+++ b/packages/google_mlkit_digital_ink_recognition/android/build.gradle
@@ -27,7 +27,7 @@ apply plugin: "kotlin-android"
 android {
     namespace = "com.google_mlkit_digital_ink_recognition"
 
-    compileSdk = 35
+    compileSdk = 36
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11

--- a/packages/google_mlkit_document_scanner/android/build.gradle
+++ b/packages/google_mlkit_document_scanner/android/build.gradle
@@ -27,7 +27,7 @@ apply plugin: "kotlin-android"
 android {
     namespace = "com.google_mlkit_document_scanner"
 
-    compileSdk = 35
+    compileSdk = 36
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11

--- a/packages/google_mlkit_entity_extraction/android/build.gradle
+++ b/packages/google_mlkit_entity_extraction/android/build.gradle
@@ -27,7 +27,7 @@ apply plugin: "kotlin-android"
 android {
     namespace = "com.google_mlkit_entity_extraction"
 
-    compileSdk = 35
+    compileSdk = 36
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11

--- a/packages/google_mlkit_face_detection/android/build.gradle
+++ b/packages/google_mlkit_face_detection/android/build.gradle
@@ -27,7 +27,7 @@ apply plugin: "kotlin-android"
 android {
     namespace = "com.google_mlkit_face_detection"
 
-    compileSdk = 35
+    compileSdk = 36
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11

--- a/packages/google_mlkit_face_mesh_detection/android/build.gradle
+++ b/packages/google_mlkit_face_mesh_detection/android/build.gradle
@@ -27,7 +27,7 @@ apply plugin: "kotlin-android"
 android {
     namespace = "com.google_mlkit_face_mesh_detection"
 
-    compileSdk = 35
+    compileSdk = 36
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11

--- a/packages/google_mlkit_genai_image_description/android/build.gradle
+++ b/packages/google_mlkit_genai_image_description/android/build.gradle
@@ -27,7 +27,7 @@ apply plugin: "kotlin-android"
 android {
     namespace = "com.google_mlkit_genai_image_description"
 
-    compileSdk = 35
+    compileSdk = 36
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11

--- a/packages/google_mlkit_genai_prompt/android/build.gradle
+++ b/packages/google_mlkit_genai_prompt/android/build.gradle
@@ -27,7 +27,7 @@ apply plugin: "kotlin-android"
 android {
     namespace = "com.google_mlkit_genai_prompt"
 
-    compileSdk = 35
+    compileSdk = 36
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11

--- a/packages/google_mlkit_genai_proofreading/android/build.gradle
+++ b/packages/google_mlkit_genai_proofreading/android/build.gradle
@@ -27,7 +27,7 @@ apply plugin: "kotlin-android"
 android {
     namespace = "com.google_mlkit_genai_proofreading"
 
-    compileSdk = 35
+    compileSdk = 36
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11

--- a/packages/google_mlkit_genai_rewriting/android/build.gradle
+++ b/packages/google_mlkit_genai_rewriting/android/build.gradle
@@ -27,7 +27,7 @@ apply plugin: "kotlin-android"
 android {
     namespace = "com.google_mlkit_genai_rewriting"
 
-    compileSdk = 35
+    compileSdk = 36
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11

--- a/packages/google_mlkit_genai_speech_recognition/android/build.gradle
+++ b/packages/google_mlkit_genai_speech_recognition/android/build.gradle
@@ -27,7 +27,7 @@ apply plugin: "kotlin-android"
 android {
     namespace = "com.google_mlkit_genai_speech_recognition"
 
-    compileSdk = 35
+    compileSdk = 36
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11

--- a/packages/google_mlkit_genai_summarization/android/build.gradle
+++ b/packages/google_mlkit_genai_summarization/android/build.gradle
@@ -27,7 +27,7 @@ apply plugin: "kotlin-android"
 android {
     namespace = "com.google_mlkit_genai_summarization"
 
-    compileSdk = 35
+    compileSdk = 36
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11

--- a/packages/google_mlkit_image_labeling/android/build.gradle
+++ b/packages/google_mlkit_image_labeling/android/build.gradle
@@ -27,7 +27,7 @@ apply plugin: "kotlin-android"
 android {
     namespace = "com.google_mlkit_image_labeling"
 
-    compileSdk = 35
+    compileSdk = 36
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11

--- a/packages/google_mlkit_language_id/android/build.gradle
+++ b/packages/google_mlkit_language_id/android/build.gradle
@@ -27,7 +27,7 @@ apply plugin: "kotlin-android"
 android {
     namespace = "com.google_mlkit_language_id"
 
-    compileSdk = 35
+    compileSdk = 36
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11

--- a/packages/google_mlkit_object_detection/android/build.gradle
+++ b/packages/google_mlkit_object_detection/android/build.gradle
@@ -27,7 +27,7 @@ apply plugin: "kotlin-android"
 android {
     namespace = "com.google_mlkit_object_detection"
 
-    compileSdk = 35
+    compileSdk = 36
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11

--- a/packages/google_mlkit_pose_detection/android/build.gradle
+++ b/packages/google_mlkit_pose_detection/android/build.gradle
@@ -27,7 +27,7 @@ apply plugin: "kotlin-android"
 android {
     namespace = "com.google_mlkit_pose_detection"
 
-    compileSdk = 35
+    compileSdk = 36
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11

--- a/packages/google_mlkit_selfie_segmentation/android/build.gradle
+++ b/packages/google_mlkit_selfie_segmentation/android/build.gradle
@@ -27,7 +27,7 @@ apply plugin: "kotlin-android"
 android {
     namespace = "com.google_mlkit_selfie_segmentation"
 
-    compileSdk = 35
+    compileSdk = 36
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11

--- a/packages/google_mlkit_smart_reply/android/build.gradle
+++ b/packages/google_mlkit_smart_reply/android/build.gradle
@@ -27,7 +27,7 @@ apply plugin: "kotlin-android"
 android {
     namespace = "com.google_mlkit_smart_reply"
 
-    compileSdk = 35
+    compileSdk = 36
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11

--- a/packages/google_mlkit_subject_segmentation/android/build.gradle
+++ b/packages/google_mlkit_subject_segmentation/android/build.gradle
@@ -27,7 +27,7 @@ apply plugin: "kotlin-android"
 android {
     namespace = "com.google_mlkit_subject_segmentation"
 
-    compileSdk = 35
+    compileSdk = 36
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11

--- a/packages/google_mlkit_text_recognition/android/build.gradle
+++ b/packages/google_mlkit_text_recognition/android/build.gradle
@@ -27,7 +27,7 @@ apply plugin: "kotlin-android"
 android {
     namespace = "com.google_mlkit_text_recognition"
 
-    compileSdk = 35
+    compileSdk = 36
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11

--- a/packages/google_mlkit_translation/android/build.gradle
+++ b/packages/google_mlkit_translation/android/build.gradle
@@ -27,7 +27,7 @@ apply plugin: "kotlin-android"
 android {
     namespace = "com.google_mlkit_translation"
 
-    compileSdk = 35
+    compileSdk = 36
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11


### PR DESCRIPTION
### Problem
Under **Android Gradle Plugin 9**, the strict `checkDebugAarMetadata` task fails the build when a plugin module compiles against an Android SDK older than what its (transitive) dependencies require — e.g. the Google native ML Kit AARs now require `compileSdk 36`. This blocks any app building on AGP 9 (Flutter's upcoming default).

### Fix
Bump `compileSdk` from 35 to **36** across **all** plugin Android modules in the monorepo (22 packages, including `google_mlkit_commons`). Build-configuration only — no source or public API changes.

Updated per review (@fbernaly: bump the rest of the plugins; @Copilot: `google_mlkit_commons` was still at 35 in-repo — now bumped too).

### Environment
- Flutter 3.44 (stable), AGP 9.x, Gradle 9.x, JDK 21